### PR TITLE
Implemented the OnCommanOnLineHelp event.

### DIFF
--- a/src/SolidEdge.Community.AddIn/RibbonControl.cs
+++ b/src/SolidEdge.Community.AddIn/RibbonControl.cs
@@ -40,6 +40,7 @@ namespace SolidEdgeCommunity.AddIn
         private bool _showLabel = true;
         private int _solidEdgeCommandId = -1;
         private string _superTip;
+        private string _webHelpURL;
 
         internal RibbonControl(int commandId)
         {
@@ -145,6 +146,11 @@ namespace SolidEdgeCommunity.AddIn
         /// Changing this value after the ribbon has been initialized has no impact.
         /// </remarks>
         public string SuperTip { get { return _superTip; } set { _superTip = value; } }
+
+        /// <summary>
+        /// Gets or set the telp URL that is shown in the browser if the user asks for help by using the F1 key.
+        /// </summary>
+        public string WebHelpURL { get { return _webHelpURL; } set { _webHelpURL = value; } }
 
         #endregion
 

--- a/src/SolidEdge.Community.AddIn/RibbonController.cs
+++ b/src/SolidEdge.Community.AddIn/RibbonController.cs
@@ -104,6 +104,18 @@ namespace SolidEdgeCommunity.AddIn
 
         void SolidEdgeFramework.ISEAddInEventsEx.OnCommandOnLineHelp(int HelpCommandID, int CommandID, out string HelpURL)
         {
+            var ribbon = ActiveRibbon;
+
+            if (ribbon != null)
+            {
+                var control = ribbon.Controls.FirstOrDefault(x => x.CommandId == CommandID);
+
+                if (control != null)
+                {
+                    HelpURL = control.WebHelpURL;
+                    return;
+                }
+            }
             HelpURL = null;
         }
 


### PR DESCRIPTION
 Also added a property called WebHelpURL to the RibbonControl class. This URL is the url that is shown in the browser if the event is fired.
I did create this pull request so you may close issue [Help event is not fired! #2](https://github.com/SolidEdgeCommunity/SolidEdge.Community.AddIn/issues/2) if this issue isn't a bug.